### PR TITLE
Ensure the use of the raw `ls` command

### DIFF
--- a/uz.zsh
+++ b/uz.zsh
@@ -17,9 +17,9 @@ zadd() {
 }
 
 zupdate() {
-  for p in $(ls -d ${UZ_PLUGIN_PATH}/*/.git); do
+  for p in $(\ls -d ${UZ_PLUGIN_PATH}/*/.git); do
     echo -e "\e[1;32m${${p%/*}:t}:\e[0m $(git -C ${p%/*} pull)"
   done
 }
 
-alias zclean="rm -rf $(echo ${UZ_PLUGINS} $(ls -d ${UZ_PLUGIN_PATH}/*) | tr ' ' '\n' | sort | uniq -u)"
+alias zclean="rm -rf $(echo ${UZ_PLUGINS} $(\ls -d ${UZ_PLUGIN_PATH}/*) | tr ' ' '\n' | sort | uniq -u)"


### PR DESCRIPTION
If the `ls` command is aliased `uz` can have issues parsing the result.
Prefixing `ls` with a `\` ensures we use the _unaliased_ version of `ls`.

eg. in my case I have aliased `ls` to `ls --color`, this causes `uz` to
not be able to read the list of plugins.

<img width="723" alt="image" src="https://user-images.githubusercontent.com/4542735/125190019-6c8f0100-e27e-11eb-98c0-2de84c53d558.png">
